### PR TITLE
https://github.com/liquibase/liquibase-hibernate/issues/136

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedColumnChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedColumnChangeGenerator.java
@@ -2,9 +2,11 @@ package liquibase.ext.hibernate.diff;
 
 import liquibase.change.Change;
 import liquibase.database.Database;
+import liquibase.diff.Difference;
 import liquibase.diff.ObjectDifferences;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.ext.hibernate.database.HibernateDatabase;
+import liquibase.statement.DatabaseFunction;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
 
@@ -31,5 +33,23 @@ public class ChangedColumnChangeGenerator extends liquibase.diff.output.changelo
         } else {
             super.handleTypeDifferences(column, differences, control, changes, referenceDatabase, comparisonDatabase);
         }
+    }
+
+    @Override
+    protected void handleDefaultValueDifferences(Column column, ObjectDifferences differences, DiffOutputControl control, List<Change> changes, Database referenceDatabase, Database comparisonDatabase) {
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            Difference difference = differences.getDifference("defaultValue");
+            if (difference != null) {
+                if (difference.getReferenceValue() == null && difference.getComparedValue() instanceof DatabaseFunction) {
+                    //database sometimes adds a function default value, like for timestamp columns
+                    return;
+                }else if(difference.getReferenceValue() instanceof DatabaseFunction && difference.getComparedValue() == null){
+                    //handle endless changesets of existing postgres sequences as default value
+                    return;
+                }
+            }
+            // do nothing, types tend to not match with hibernate
+        }
+            super.handleDefaultValueDifferences(column, differences, control, changes, referenceDatabase, comparisonDatabase);
     }
 }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedForeignKeyChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedForeignKeyChangeGenerator.java
@@ -25,10 +25,13 @@ public class ChangedForeignKeyChangeGenerator extends liquibase.diff.output.chan
 
     @Override
     public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
-//        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
-//            return null;
-//        } else {
-            return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
-//        }
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            differences.removeDifference("deleteRule");
+            differences.removeDifference("updateRule");
+            if (!differences.hasDifferences()) {
+                return null;
+            }
+        }
+        return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
     }
 }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedIndexChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedIndexChangeGenerator.java
@@ -1,0 +1,43 @@
+package liquibase.ext.hibernate.diff;
+
+import liquibase.change.Change;
+import liquibase.database.Database;
+import liquibase.diff.Difference;
+import liquibase.diff.ObjectDifferences;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.ext.hibernate.database.HibernateDatabase;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Index;
+
+/**
+ * Hibernate doesn't know about all the variations that occur with index constraint but just whether they exists or not.
+ * To prevent changing customized constraints, we suppress all changes with hibernate.
+ */
+
+public class ChangedIndexChangeGenerator extends
+        liquibase.diff.output.changelog.core.ChangedIndexChangeGenerator {
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (Index.class.isAssignableFrom(objectType)) {
+            return PRIORITY_ADDITIONAL;
+        }
+        return PRIORITY_NONE;
+    }
+
+    @Override
+    public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences,
+                               DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase,
+                               ChangeGeneratorChain chain) {
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            Difference difference = differences.getDifference("unique");
+            if (difference != null) {
+                if (difference.getReferenceValue() == null && (Boolean)difference.getComparedValue() == false) {
+                    return null;
+                }
+            }
+        }
+        return super.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase, chain);
+    }
+}

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedUniqueConstraintChangeGenerator.java
@@ -2,6 +2,7 @@ package liquibase.ext.hibernate.diff;
 
 import liquibase.change.Change;
 import liquibase.database.Database;
+import liquibase.diff.Difference;
 import liquibase.diff.ObjectDifferences;
 import liquibase.diff.compare.CompareControl;
 import liquibase.diff.output.DiffOutputControl;
@@ -37,11 +38,15 @@ public class ChangedUniqueConstraintChangeGenerator implements ChangedObjectChan
 
     @Override
     public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
-//        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
-//            return null;
-//        } else {
-            return chain.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase);
-//        }
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            Difference difference = differences.getDifference("unique");
+            if (difference != null) {
+                if (difference.getReferenceValue() == null && (Boolean)(difference.getComparedValue()) == true) {
+                    return null;
+                }
+            }
+        }
+        return chain.fixChanged(changedObject, differences, control, referenceDatabase, comparisonDatabase);
     }
 
     @Override

--- a/src/main/java/liquibase/ext/hibernate/diff/MissingSequenceChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/MissingSequenceChangeGenerator.java
@@ -1,0 +1,36 @@
+package liquibase.ext.hibernate.diff;
+
+import liquibase.change.Change;
+import liquibase.database.Database;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.ext.hibernate.database.HibernateDatabase;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
+
+/**
+ * Don't generate sequences if database does not support it
+ */
+public class MissingSequenceChangeGenerator extends liquibase.diff.output.changelog.core.MissingSequenceChangeGenerator {
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (Sequence.class.isAssignableFrom(objectType)) {
+            return PRIORITY_ADDITIONAL;
+        }
+        return PRIORITY_NONE;
+    }
+
+    @Override
+    public Change[] fixMissing(DatabaseObject missingObject, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        if (referenceDatabase instanceof HibernateDatabase && !comparisonDatabase.supportsSequences()) {
+            System.out.println("MissingSequenceChangeGenerator Skipping");
+            return null;
+        } else if (comparisonDatabase instanceof HibernateDatabase && !referenceDatabase.supportsSequences()) {
+            System.out.println("MissingSequenceChangeGenerator Skipping");
+            return null;
+        }else {
+            return super.fixMissing(missingObject, control, referenceDatabase, comparisonDatabase, chain);
+        }
+    }
+}

--- a/src/main/java/liquibase/ext/hibernate/diff/UnexpectedIndexChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/UnexpectedIndexChangeGenerator.java
@@ -24,10 +24,10 @@ public class UnexpectedIndexChangeGenerator extends liquibase.diff.output.change
 
     @Override
     public Change[] fixUnexpected(DatabaseObject unexpectedObject, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
-//        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
-//            return null;
-//        } else {
+        if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
+            return null;
+        } else {
             return super.fixUnexpected(unexpectedObject, control, referenceDatabase, comparisonDatabase, chain);
-//        }
+        }
     }
 }


### PR DESCRIPTION
Merged the hibernate 5 fixes down to hibernate4 branch
https://github.com/liquibase/liquibase-hibernate/issues/129

Also added additional checks that fixed a lot of the recreation bugs in diffs.
Tested against same db used in bug 136.

It still has some recreation bugs, but this makes the library usable for me again for database migration.